### PR TITLE
feat: localize paint options

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -136,5 +136,8 @@
   "expandMode": "Expand Mode",
   "minimize": "Minimize",
   "restore": "Restore",
-  "hideStats": "Hide Stats"
+  "hideStats": "Hide Stats",
+  "paintOptions": "Paint Options",
+  "paintWhitePixels": "Paint White Pixels",
+  "paintTransparentPixels": "Paint Transparent Pixels"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -137,5 +137,8 @@
   "expandMode": "Mode Étendu",
   "minimize": "Réduire",
   "restore": "Restaurer",
-  "hideStats": "Masquer les Stats"
+  "hideStats": "Masquer les Stats",
+  "paintOptions": "Options de peinture",
+  "paintWhitePixels": "Peindre les pixels blancs",
+  "paintTransparentPixels": "Peindre les pixels transparents"
 }

--- a/lang/id.json
+++ b/lang/id.json
@@ -137,5 +137,8 @@
   "expandMode": "Mode Perluas",
   "minimize": "Minimalkan",
   "restore": "Pulihkan",
-  "hideStats": "Sembunyikan Statistik"
+  "hideStats": "Sembunyikan Statistik",
+  "paintOptions": "Opsi Pewarnaan",
+  "paintWhitePixels": "Warnai piksel putih",
+  "paintTransparentPixels": "Warnai piksel transparan"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -137,5 +137,8 @@
   "expandMode": "展開モード",
   "minimize": "最小化",
   "restore": "復元",
-  "hideStats": "統計を非表示"
+  "hideStats": "統計を非表示",
+  "paintOptions": "描画オプション",
+  "paintWhitePixels": "白いピクセルを描画",
+  "paintTransparentPixels": "透明ピクセルを描画"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -137,5 +137,8 @@
   "expandMode": "확장 모드",
   "minimize": "최소화",
   "restore": "복원",
-  "hideStats": "통계 숨김"
+  "hideStats": "통계 숨김",
+  "paintOptions": "페인트 옵션",
+  "paintWhitePixels": "흰색 픽셀 칠하기",
+  "paintTransparentPixels": "투명 픽셀 칠하기"
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -136,5 +136,8 @@
   "expandMode": "Modo Expandir",
   "minimize": "Minimizar",
   "restore": "Restaurar",
-  "hideStats": "Ocultar Estatísticas"
+  "hideStats": "Ocultar Estatísticas",
+  "paintOptions": "Opções de pintura",
+  "paintWhitePixels": "Pintar pixels brancos",
+  "paintTransparentPixels": "Pintar pixels transparentes"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -136,5 +136,8 @@
   "expandMode": "Режим расширения",
   "minimize": "Свернуть",
   "restore": "Восстановить",
-  "hideStats": "Скрыть статистику"
+  "hideStats": "Скрыть статистику",
+  "paintOptions": "Параметры рисования",
+  "paintWhitePixels": "Рисовать белые пиксели",
+  "paintTransparentPixels": "Рисовать прозрачные пиксели"
 }

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -137,5 +137,8 @@
   "expandMode": "Genişletme Modu",
   "minimize": "Küçült",
   "restore": "Geri Yükle",
-  "hideStats": "İstatistikleri Gizle"
+  "hideStats": "İstatistikleri Gizle",
+  "paintOptions": "Boya Seçenekleri",
+  "paintWhitePixels": "Beyaz pikselleri boya",
+  "paintTransparentPixels": "Şeffaf pikselleri boya"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -137,5 +137,8 @@
   "expandMode": "Режим розширення",
   "minimize": "Мінімізувати",
   "restore": "Відновити",
-  "hideStats": "Приховати статистику"
+  "hideStats": "Приховати статистику",
+  "paintOptions": "Параметри малювання",
+  "paintWhitePixels": "Малювати білі пікселі",
+  "paintTransparentPixels": "Малювати прозорі пікселі"
 }

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -137,5 +137,8 @@
   "expandMode": "Chế độ mở rộng",
   "minimize": "Thu nhỏ",
   "restore": "Khôi phục",
-  "hideStats": "Ẩn thống kê"
+  "hideStats": "Ẩn thống kê",
+  "paintOptions": "Tùy chọn vẽ",
+  "paintWhitePixels": "Vẽ điểm ảnh trắng",
+  "paintTransparentPixels": "Vẽ điểm ảnh trong suốt"
 }

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -137,5 +137,8 @@
   "expandMode": "展开模式",
   "minimize": "最小化",
   "restore": "恢复",
-  "hideStats": "隐藏统计"
+  "hideStats": "隐藏统计",
+  "paintOptions": "绘图选项",
+  "paintWhitePixels": "绘制白色像素",
+  "paintTransparentPixels": "绘制透明像素"
 }

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -137,5 +137,8 @@
   "expandMode": "展開模式",
   "minimize": "最小化",
   "restore": "恢復",
-  "hideStats": "隱藏統計"
+  "hideStats": "隱藏統計",
+  "paintOptions": "繪圖選項",
+  "paintWhitePixels": "繪製白色像素",
+  "paintTransparentPixels": "繪製透明像素"
 }


### PR DESCRIPTION
## Summary
- add paint options translations to language JSON files

## Testing
- `node -e "const fs=require('fs');fs.readdirSync('lang').forEach(f=>{JSON.parse(fs.readFileSync('lang/'+f,'utf8'));});console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68b3f7a3fccc83279e21e45ebe857515