### PR TITLE
feat: add option to skip identical pixels

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -139,5 +139,6 @@
   "hideStats": "Hide Stats",
   "paintOptions": "Paint Options",
   "paintWhitePixels": "Paint White Pixels",
-  "paintTransparentPixels": "Paint Transparent Pixels"
+  "paintTransparentPixels": "Paint Transparent Pixels",
+  "onlyDifferentPixels": "Only paint different color pixels"
 }

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -140,5 +140,6 @@
   "hideStats": "隐藏统计",
   "paintOptions": "绘图选项",
   "paintWhitePixels": "绘制白色像素",
-  "paintTransparentPixels": "绘制透明像素"
+  "paintTransparentPixels": "绘制透明像素",
+  "onlyDifferentPixels": "仅绘制不同的色块"
 }


### PR DESCRIPTION
## Summary
- add checkbox to paint only differing pixels
- skip painting if board already matches target color
- localize new option in English and Simplified Chinese

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check Auto-Image.js`
- `node -e "JSON.parse(require('fs').readFileSync('lang/en.json','utf8')); JSON.parse(require('fs').readFileSync('lang/zh-CN.json','utf8')); console.log('json ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68b4649ae10c832790f95086d4fb56a0