### PR TITLE
feat: show overlay instead of auto painting

### DIFF
--- a/Auto-Image.js
+++ b/Auto-Image.js
@@ -5133,48 +5133,23 @@ function applyTheme() {
       })
     }
 
-    async function startPainting() {
-      if (!state.imageLoaded || !state.startPosition || !state.region) {
-        updateUI("missingRequirements", "error")
-        return false
-      }
-      await ensureToken()
-      if (!turnstileToken) return false
-
-      state.running = true
-      state.stopFlag = false
-      startBtn.disabled = true
-      stopBtn.disabled = false
-      uploadBtn.disabled = true
-      selectPosBtn.disabled = true
-      resizeBtn.disabled = true
-      saveBtn.disabled = true
-      toggleOverlayBtn.disabled = true;
-
-      updateUI("startPaintingMsg", "success")
-
-      try {
-        await processImage()
-        return true
-      } catch {
-        updateUI("paintingError", "error")
-        return false
-      } finally {
-        state.running = false
-        stopBtn.disabled = true
-        saveBtn.disabled = false
-
-        if (!state.stopFlag) {
-          startBtn.disabled = true
-          uploadBtn.disabled = false
-          selectPosBtn.disabled = false
-          resizeBtn.disabled = false
-        } else {
-          startBtn.disabled = false
+      async function startPainting() {
+        if (!state.imageLoaded || !state.startPosition || !state.region) {
+          updateUI("missingRequirements", "error")
+          return false
         }
-        toggleOverlayBtn.disabled = false;
+
+        // Show the final template overlay instead of painting automatically
+        overlayManager.enable()
+        toggleOverlayBtn.classList.add('active')
+        toggleOverlayBtn.setAttribute('aria-pressed', 'true')
+        Utils.showAlert(Utils.t("overlayEnabled"), "info")
+
+        // Disable controls related to auto painting
+        startBtn.disabled = true
+        stopBtn.disabled = true
+        return true
       }
-    }
 
     if (startBtn) {
       startBtn.addEventListener("click", startPainting)


### PR DESCRIPTION
## Summary
- stop automatically drawing pixels and only show final overlay when the paint button is pressed

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc09666e34832790198e8a0ca7da38