### PR TITLE
feat(auto-image): add verify-before-paint setting

### DIFF
--- a/Extension/lang/de.json
+++ b/Extension/lang/de.json
@@ -70,5 +70,9 @@
   "captchaSolving": "🔑 Generiere Turnstile-Token...",
   "captchaFailed": "❌ Turnstile-Token-Generierung fehlgeschlagen. Versuche Fallback-Methode...",
   "automation": "Automatisierung",
-  "noChargesThreshold": "⌛ Warte bis {threshold} Ladungen erreicht sind. Aktuell {current}. Nächste in {time}..."
+  "noChargesThreshold": "⌛ Warte bis {threshold} Ladungen erreicht sind. Aktuell {current}. Nächste in {time}...",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/en.json
+++ b/Extension/lang/en.json
@@ -150,5 +150,9 @@
   "paintTransparentPixels": "Paint Transparent",
   "paintTransparentPixelsDescription": "If enabled, template transparent pixels will be painted",
   "paintUnavailablePixels": "Paint Unavailable",
-  "paintUnavailablePixelsDescription": "If enabled, template colors that are unavailable will be painted using the closest available color"
+  "paintUnavailablePixelsDescription": "If enabled, template colors that are unavailable will be painted using the closest available color",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/fr.json
+++ b/Extension/lang/fr.json
@@ -140,5 +140,9 @@
   "hideStats": "Masquer les Stats",
   "paintOptions": "Options de peinture",
   "paintWhitePixels": "Peindre les pixels blancs",
-  "paintTransparentPixels": "Peindre les pixels transparents"
+  "paintTransparentPixels": "Peindre les pixels transparents",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/id.json
+++ b/Extension/lang/id.json
@@ -140,5 +140,9 @@
   "hideStats": "Sembunyikan Statistik",
   "paintOptions": "Opsi Pewarnaan",
   "paintWhitePixels": "Warnai piksel putih",
-  "paintTransparentPixels": "Warnai piksel transparan"
+  "paintTransparentPixels": "Warnai piksel transparan",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/ja.json
+++ b/Extension/lang/ja.json
@@ -140,5 +140,9 @@
   "hideStats": "統計を非表示",
   "paintOptions": "描画オプション",
   "paintWhitePixels": "白いピクセルを描画",
-  "paintTransparentPixels": "透明ピクセルを描画"
+  "paintTransparentPixels": "透明ピクセルを描画",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/ko.json
+++ b/Extension/lang/ko.json
@@ -140,5 +140,9 @@
   "hideStats": "통계 숨김",
   "paintOptions": "페인트 옵션",
   "paintWhitePixels": "흰색 픽셀 칠하기",
-  "paintTransparentPixels": "투명 픽셀 칠하기"
+  "paintTransparentPixels": "투명 픽셀 칠하기",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/pt.json
+++ b/Extension/lang/pt.json
@@ -139,5 +139,9 @@
   "hideStats": "Ocultar Estatísticas",
   "paintOptions": "Opções de pintura",
   "paintWhitePixels": "Pintar pixels brancos",
-  "paintTransparentPixels": "Pintar pixels transparentes"
+  "paintTransparentPixels": "Pintar pixels transparentes",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/ru.json
+++ b/Extension/lang/ru.json
@@ -139,5 +139,9 @@
   "hideStats": "Скрыть статистику",
   "paintOptions": "Параметры рисования",
   "paintWhitePixels": "Рисовать белые пиксели",
-  "paintTransparentPixels": "Рисовать прозрачные пиксели"
+  "paintTransparentPixels": "Рисовать прозрачные пиксели",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/tr.json
+++ b/Extension/lang/tr.json
@@ -140,5 +140,9 @@
   "hideStats": "İstatistikleri Gizle",
   "paintOptions": "Boya Seçenekleri",
   "paintWhitePixels": "Beyaz pikselleri boya",
-  "paintTransparentPixels": "Şeffaf pikselleri boya"
+  "paintTransparentPixels": "Şeffaf pikselleri boya",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/uk.json
+++ b/Extension/lang/uk.json
@@ -140,5 +140,9 @@
   "hideStats": "Приховати статистику",
   "paintOptions": "Параметри малювання",
   "paintWhitePixels": "Малювати білі пікселі",
-  "paintTransparentPixels": "Малювати прозорі пікселі"
+  "paintTransparentPixels": "Малювати прозорі пікселі",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/vi.json
+++ b/Extension/lang/vi.json
@@ -140,5 +140,9 @@
   "hideStats": "Ẩn thống kê",
   "paintOptions": "Tùy chọn vẽ",
   "paintWhitePixels": "Vẽ điểm ảnh trắng",
-  "paintTransparentPixels": "Vẽ điểm ảnh trong suốt"
+  "paintTransparentPixels": "Vẽ điểm ảnh trong suốt",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/zh-CN.json
+++ b/Extension/lang/zh-CN.json
@@ -140,5 +140,9 @@
   "hideStats": "隐藏统计",
   "paintOptions": "绘图选项",
   "paintWhitePixels": "绘制白色像素",
-  "paintTransparentPixels": "绘制透明像素"
+  "paintTransparentPixels": "绘制透明像素",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }

--- a/Extension/lang/zh-TW.json
+++ b/Extension/lang/zh-TW.json
@@ -140,5 +140,9 @@
   "hideStats": "隱藏統計",
   "paintOptions": "繪圖選項",
   "paintWhitePixels": "繪製白色像素",
-  "paintTransparentPixels": "繪製透明像素"
+  "paintTransparentPixels": "繪製透明像素",
+  "verifyBeforePainting": "Verify Before Painting",
+  "verifyBeforePaintingDescription": "Compare board pixels before painting to skip already correct colors.",
+  "verifyBeforePaintingEnabled": "Pixel verification before painting enabled.",
+  "verifyBeforePaintingDisabled": "Pixel verification before painting disabled."
 }


### PR DESCRIPTION
## Summary
- add a configurable "verify before painting" toggle to auto-image settings, defaulting to on
- gate the live canvas comparison by the new setting and persist it via saved bot settings
- localize the new option text across bundled language files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d538dbf7788327aa6d191a65b650e3